### PR TITLE
fix. In iOS Facebook LoginManager always return '.cancelled'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
 func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
   if CAPBridge.handleOpenUrl(url, options) {
-    return true;
+    return SDKApplicationDelegate.shared.application(app, open: url, options: options)
   }
-    
-  return SDKApplicationDelegate.shared.application(app, open: url, options: options)
+  else{
+    return false
+  }
 }
 ```
 


### PR DESCRIPTION
In original tutorial, iOS facebook login is always failed.(LoginManager return 'canceled'.).
The following is the cause.
At  'open url' func of AppDelegate class , 'SDKApplicationDelegate.shared.application' never called, because 'CAPBridge.handleOpenUrl' always return true. 
