### PR TITLE
Upgrade package.json to use capacitor 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "author": "Masahiko Sakakibara",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "1.4.0"
   },
   "devDependencies": {
     "typescript": "^3.2.4",
-    "@capacitor/ios": "latest",
-    "@capacitor/android": "latest"
+    "@capacitor/ios": "1.4.0",
+    "@capacitor/android": "1.4.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Per the comments in this issue (https://github.com/rdlabo/capacitor-facebook-login/issues/6#issuecomment-529864719), I cannot use this plugin with an upgraded capacitor unless the plugin capacitor version matches my project capacitor version.