### PR TITLE
Upgrade package.json to use capacitor 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "author": "Masahiko Sakakibara",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "1.4.0"
+    "@capacitor/core": "1.5.1"
   },
   "devDependencies": {
     "typescript": "^3.2.4",
-    "@capacitor/ios": "1.4.0",
-    "@capacitor/android": "1.4.0"
+    "@capacitor/ios": "1.5.1",
+    "@capacitor/android": "1.5.1"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Per the comments in this issue (#6 (comment)), I cannot use this plugin with an upgraded capacitor unless the plugin capacitor version matches my project capacitor version.

[My previous PR to upgrade for Capacitor 1.4.0](https://github.com/rdlabo/capacitor-facebook-login/pull/20)